### PR TITLE
ajustado bug de quando notifica novas paginas

### DIFF
--- a/App/Controllers/Notificacoes.php
+++ b/App/Controllers/Notificacoes.php
@@ -96,7 +96,7 @@ class Notificacoes extends Action
 
     public function notifica($badge, $tipo)
     {
-        if($_SESSION[$tipo] != $badge) {
+        if($_SESSION[$tipo] < $badge) {
             $_SESSION[$tipo] = $badge;
 
             if ($badge != 0) {


### PR DESCRIPTION
agora sempre que o badge for maior do que o numero de notificacoes armazenado na session, apita, após o apito atualiza o numero de notificacoes da session com o numero atual do badge
